### PR TITLE
Change the Theme of the project in order to match the Figma

### DIFF
--- a/app/src/main/java/com/swentseekr/seekr/ui/theme/Color.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/theme/Color.kt
@@ -9,7 +9,7 @@ val Pink80 = Color(0xFFEFB8C8)
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
-//val GrassGreen = Color(0xFF4CAF50)
+val GrassGreen = Color(0xFF4CAF50)
 val Black = Color(0xFF000000)
 val White = Color(0xFFFFFFFF)
 
@@ -34,4 +34,3 @@ val LightOnError = Color(0xFFFFFFFF)
 
 val DarkError = Color(0xFFFFB4AB)
 val DarkOnError = Color(0xFF690005)
-

--- a/app/src/main/java/com/swentseekr/seekr/ui/theme/Theme.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/theme/Theme.kt
@@ -16,7 +16,8 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
 private val DarkColorScheme =
-    darkColorScheme(primary = Green,
+    darkColorScheme(
+        primary = Green,
         onPrimary = Black,
         secondary = Orange,
         onSecondary = GrayDislike,
@@ -27,8 +28,7 @@ private val DarkColorScheme =
         surface = GrayBackgound,
         onSurface = Black,
         error = DarkError,
-        onError = DarkOnError
-    )
+        onError = DarkOnError)
 
 private val LightColorScheme =
     lightColorScheme(
@@ -44,7 +44,7 @@ private val LightColorScheme =
         onSurface = Black,
         error = LightError,
         onError = LightOnError,
-        )
+    )
 
 @Composable
 fun SampleAppTheme(

--- a/app/src/main/java/com/swentseekr/seekr/ui/theme/Type.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/theme/Type.kt
@@ -9,44 +9,43 @@ import androidx.compose.ui.unit.sp
 // Set of Material typography styles to start with
 val Typography =
     Typography(
-        //For Very large text app name in sign in screen
-        displayLarge = TextStyle(
-            fontFamily = FontFamily.Default,
-            fontWeight = FontWeight.Normal,
-            fontSize = 57.sp,
-            lineHeight = 64.sp,
-            letterSpacing = -0.25.sp
-        ),
+        // For Very large text app name in sign in screen
+        displayLarge =
+            TextStyle(
+                fontFamily = FontFamily.Default,
+                fontWeight = FontWeight.Normal,
+                fontSize = 57.sp,
+                lineHeight = 64.sp,
+                letterSpacing = -0.25.sp),
         // For Screen Titles
-        headlineLarge = TextStyle(
-            fontFamily = FontFamily.Default,
-            fontWeight = FontWeight.Normal,
-            fontSize = 32.sp,
-            lineHeight = 40.sp,
-            letterSpacing = 0.sp
-        ),
-        //For Card Titles
-        titleLarge = TextStyle(
-            fontFamily = FontFamily.Default,
-            fontWeight = FontWeight.Medium,
-            fontSize = 22.sp,
-            lineHeight = 28.sp,
-            letterSpacing = 0.sp
-        ),
+        headlineLarge =
+            TextStyle(
+                fontFamily = FontFamily.Default,
+                fontWeight = FontWeight.Normal,
+                fontSize = 32.sp,
+                lineHeight = 40.sp,
+                letterSpacing = 0.sp),
+        // For Card Titles
+        titleLarge =
+            TextStyle(
+                fontFamily = FontFamily.Default,
+                fontWeight = FontWeight.Medium,
+                fontSize = 22.sp,
+                lineHeight = 28.sp,
+                letterSpacing = 0.sp),
         // For Main body content
-        bodyLarge = TextStyle(
+        bodyLarge =
+            TextStyle(
                 fontFamily = FontFamily.Default,
                 fontWeight = FontWeight.Normal,
                 fontSize = 16.sp,
                 lineHeight = 24.sp,
-                letterSpacing = 0.5.sp
-        ),
+                letterSpacing = 0.5.sp),
         // For small text and captions
-        labelSmall = TextStyle(
-            fontFamily = FontFamily.Default,
-            fontWeight = FontWeight.Medium,
-            fontSize = 11.sp,
-            lineHeight = 16.sp,
-            letterSpacing = 0.5.sp
-        )
-    )
+        labelSmall =
+            TextStyle(
+                fontFamily = FontFamily.Default,
+                fontWeight = FontWeight.Medium,
+                fontSize = 11.sp,
+                lineHeight = 16.sp,
+                letterSpacing = 0.5.sp))


### PR DESCRIPTION
### Task
Change the Theme directory in order to match the Figma's color and typography.

### Description
This pull request  completes theme setup for the Seekr app, including both light and dark color schemes and typography styles for various UI elements.

### What has been changed?
**Theme Colors**
Defined a consistent color palette in ui.theme/Color.kt, including:

- Primary colors (e.g., Green, Orange, Gray, Black, White)
- Status-based colors for difficulty levels (EasyGreen, MediumYellow, DifficultRed)
- UI element colors for buttons, stars, rankings, and error states

**Light & Dark Themes**

- Created separate LightColorScheme and DarkColorScheme

**Typography Styles**

- Defined custom Typography styles in ui.theme/Type.kt, including:

1. displayLarge – App name
2. headlineLarge – Screen titles
3.  titleLarge – Card titles
4. bodyLarge – Main content text
5. labelSmall – Captions and small labels

**Why was this change made?**

- Ensures a consistent visual design across the app
- Supports light/dark mode 
