### PR TITLE
Feature/hunt repository firebase

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -145,6 +145,10 @@ dependencies {
     // Cloud Firestore
     implementation("com.google.firebase:firebase-firestore")
 
+    implementation("com.google.protobuf:protobuf-javalite:3.21.12")
+    testImplementation("com.google.protobuf:protobuf-javalite:3.21.12")
+    androidTestImplementation("com.google.protobuf:protobuf-javalite:3.21.12")
+
     // Google Maps Compose library
     val mapsComposeVersion = "4.4.1"
     implementation("com.google.maps.android:maps-compose:$mapsComposeVersion")
@@ -268,4 +272,8 @@ configurations.matching { it.name.contains("test", ignoreCase = true) }.all {
         force("org.jacoco:org.jacoco.report:0.8.12")
         force("org.jacoco:org.jacoco.ant:0.8.12")
     }
+}
+
+configurations.configureEach {
+    exclude(group = "com.google.protobuf", module = "protobuf-lite")
 }

--- a/app/src/androidTest/java/com/swentseekr/seekr/HuntCardTest.kt
+++ b/app/src/androidTest/java/com/swentseekr/seekr/HuntCardTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.swentseekr.seekr.model.author.Author
 import com.swentseekr.seekr.model.hunt.Difficulty
 import com.swentseekr.seekr.model.hunt.Hunt
 import com.swentseekr.seekr.model.hunt.HuntStatus
@@ -35,7 +34,7 @@ class HuntCardTest {
           time = 2.5,
           distance = 5.0,
           difficulty = Difficulty.DIFFICULT,
-          author = Author("spike man", "", 1, 2.5, 3.0),
+          authorId = "0",
           image = R.drawable.ic_launcher_foreground, // ou une image de ton projet
           reviewRate = 4.5)
 
@@ -45,7 +44,7 @@ class HuntCardTest {
     composeTestRule.setContent { HuntCard(hunt, modifier = Modifier.padding(2.dp)) }
 
     composeTestRule.onNodeWithText(hunt.title).assertIsDisplayed()
-    composeTestRule.onNodeWithText("by ${hunt.author.pseudonym}").assertIsDisplayed()
+    composeTestRule.onNodeWithText("by ${hunt.authorId}").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/swentseekr/seekr/model/hunt/HuntsRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/swentseekr/seekr/model/hunt/HuntsRepositoryFirestoreTest.kt
@@ -1,12 +1,11 @@
 package com.swentseekr.seekr.model.hunt
 
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.FirebaseFirestore
-import com.swentseekr.seekr.model.author.Author
 import com.swentseekr.seekr.model.map.Location
 import com.swentseekr.seekr.utils.FirebaseTestEnvironment
+import com.swentseekr.seekr.utils.FirebaseTestEnvironment.clearEmulatorData
 import junit.framework.TestCase.assertEquals
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
@@ -15,7 +14,7 @@ import org.junit.Test
 class HuntsRepositoryFirestoreTest {
 
   private var repository: HuntsRepository = HuntRepositoryProvider.repository
-  val hunt1 =
+  var hunt1 =
       Hunt(
           uid = "hunt1",
           start = Location(40.7128, -74.0060, "New York"),
@@ -27,13 +26,21 @@ class HuntsRepositoryFirestoreTest {
           time = 2.5,
           distance = 5.0,
           difficulty = Difficulty.EASY,
-          author = Author("spike man", "", 1, 2.5, 3.0),
+          authorId = "0",
           image = 0,
           reviewRate = 4.5)
 
   @Before
   fun setUp() {
+
     FirebaseTestEnvironment.setup()
+    runTest {
+      if (FirebaseTestEnvironment.isEmulatorActive()) {
+        clearEmulatorData()
+      }
+      FirebaseAuth.getInstance().signInAnonymously().await()
+      hunt1 = hunt1.copy(authorId = FirebaseAuth.getInstance().currentUser?.uid ?: "0")
+    }
   }
 
   @Test

--- a/app/src/main/java/com/swentseekr/seekr/model/hunt/Hunt.kt
+++ b/app/src/main/java/com/swentseekr/seekr/model/hunt/Hunt.kt
@@ -1,6 +1,5 @@
 package com.swentseekr.seekr.model.hunt
 
-import com.swentseekr.seekr.model.author.Author
 import com.swentseekr.seekr.model.map.Location
 
 data class Hunt(
@@ -14,7 +13,7 @@ data class Hunt(
     val time: Double,
     val distance: Double,
     val difficulty: Difficulty,
-    val author: Author,
+    val authorId: String,
     val image: Int,
     val reviewRate: Double
 )

--- a/app/src/main/java/com/swentseekr/seekr/model/hunt/HuntRepositoryProvider.kt
+++ b/app/src/main/java/com/swentseekr/seekr/model/hunt/HuntRepositoryProvider.kt
@@ -2,7 +2,6 @@ package com.swentseekr.seekr.model.hunt
 
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
-import com.swentseekr.seekr.model.author.Author
 import com.swentseekr.seekr.model.map.Location
 import kotlinx.coroutines.runBlocking
 
@@ -26,7 +25,7 @@ object HuntRepositoryProvider {
                     time = 2.5,
                     distance = 5.0,
                     difficulty = Difficulty.EASY,
-                    author = Author("spike man", "", 1, 2.5, 3.0),
+                    authorId = "0",
                     image = 0,
                     reviewRate = 4.5),
                 Hunt(
@@ -40,7 +39,7 @@ object HuntRepositoryProvider {
                     time = 3.0,
                     distance = 6.0,
                     difficulty = Difficulty.INTERMEDIATE,
-                    author = Author("holly wood", "", 2, 3.5, 4.0),
+                    authorId = "1",
                     image = 1,
                     reviewRate = 4.0),
             )
@@ -48,6 +47,8 @@ object HuntRepositoryProvider {
         runBlocking { sampleHunts.forEach { hunt -> addHunt(hunt) } }
       }
 
-    private val _repositoryFirestore: HuntsRepository by lazy { HuntsRepositoryFirestore(Firebase.firestore)}
+  private val _repositoryFirestore: HuntsRepository by lazy {
+    HuntsRepositoryFirestore(Firebase.firestore)
+  }
   var repository: HuntsRepository = _repositoryFirestore
 }

--- a/app/src/main/java/com/swentseekr/seekr/model/profile/MockProfileData.kt
+++ b/app/src/main/java/com/swentseekr/seekr/model/profile/MockProfileData.kt
@@ -7,13 +7,6 @@ import com.swentseekr.seekr.model.map.Location
 import com.swentseekr.seekr.ui.profile.Profile
 
 fun mockProfileData(): Profile {
-  val author =
-      Author(
-          pseudonym = "Spike Man",
-          bio = "Avid adventurer and puzzle solver.",
-          profilePicture = 0,
-          reviewRate = 4.5,
-          sportRate = 4.8)
 
   val sampleHunt =
       Hunt(
@@ -27,13 +20,13 @@ fun mockProfileData(): Profile {
           time = 2.5,
           distance = 5.0,
           difficulty = Difficulty.DIFFICULT,
-          author = author,
+          authorId = "0",
           image = R.drawable.ic_launcher_foreground,
           reviewRate = 4.5)
 
   return Profile(
       uid = "user123",
-      author = author,
+      author = sampleAuthor(),
       myHunts = mutableListOf(sampleHunt),
       doneHunts = mutableListOf(),
       likedHunts = mutableListOf())
@@ -73,7 +66,7 @@ fun createHunt(uid: String, title: String) =
         time = 1.0,
         distance = 2.0,
         difficulty = Difficulty.EASY,
-        author = sampleAuthor(),
+        authorId = "0",
         image = R.drawable.empty_user,
         reviewRate = 4.0)
 

--- a/app/src/main/java/com/swentseekr/seekr/ui/components/HuntCard.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/components/HuntCard.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.swentseekr.seekr.R
-import com.swentseekr.seekr.model.author.Author
 import com.swentseekr.seekr.model.hunt.Difficulty
 import com.swentseekr.seekr.model.hunt.Hunt
 import com.swentseekr.seekr.model.hunt.HuntStatus
@@ -69,7 +68,7 @@ fun HuntCard(
             // tint = if(huntUiState.isLiked) Color.Red else Color.Gray)
             tint = Color.Red)
       }
-      Text("by ${hunt.author.pseudonym}", modifier = Modifier.padding(horizontal = 4.dp))
+      Text("by ${hunt.authorId}", modifier = Modifier.padding(horizontal = 4.dp))
       Row {
         Image(
             painter = painterResource(id = hunt.image),
@@ -139,7 +138,7 @@ fun HuntCardPreview() {
           time = 2.5,
           distance = 5.0,
           difficulty = Difficulty.DIFFICULT,
-          author = Author("spike man", "", 1, 2.5, 3.0),
+          authorId = "0",
           image = R.drawable.ic_launcher_foreground, // ou une image de ton projet
           reviewRate = 4.5)
   var isLiked by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/swentseekr/seekr/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/overview/OverviewScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.swentseekr.seekr.R
-import com.swentseekr.seekr.model.author.Author
 import com.swentseekr.seekr.model.hunt.Difficulty
 import com.swentseekr.seekr.model.hunt.Hunt
 import com.swentseekr.seekr.model.hunt.HuntStatus
@@ -65,7 +64,7 @@ fun OverviewScreen(
           time = 2.5,
           distance = 5.0,
           difficulty = Difficulty.EASY,
-          author = Author("spike man", "", 1, 2.5, 3.0),
+          authorId = "0",
           image = R.drawable.ic_launcher_foreground,
           reviewRate = 4.5)
   val hunts =

--- a/app/src/main/java/com/swentseekr/seekr/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/overview/OverviewViewModel.kt
@@ -105,8 +105,7 @@ class OverviewViewModel(
             it.hunt.title.contains(newSearch, ignoreCase = true) ||
                 it.hunt.description.contains(newSearch, ignoreCase = true) ||
                 it.hunt.status.toString().contains(newSearch, ignoreCase = true) ||
-                it.hunt.difficulty.toString().contains(newSearch, ignoreCase = true) ||
-                it.hunt.author.pseudonym.contains(newSearch, ignoreCase = true)
+                it.hunt.difficulty.toString().contains(newSearch, ignoreCase = true)
           }
       _uiState.value = _uiState.value.copy(hunts = filteredHunts)
     }

--- a/app/src/main/java/com/swentseekr/seekr/ui/profile/Profile.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/profile/Profile.kt
@@ -237,7 +237,7 @@ fun ProfileScreenPreview() {
                     time = 2.5,
                     distance = 5.0,
                     difficulty = Difficulty.DIFFICULT,
-                    author = Author("spike man", "", 1, 2.5, 3.0),
+                    authorId = "0",
                     image = R.drawable.ic_launcher_foreground,
                     reviewRate = 4.5)
               },

--- a/app/src/test/java/com/swentseekr/seekr/model/hunt/HuntsRepositoryLocalTest.kt
+++ b/app/src/test/java/com/swentseekr/seekr/model/hunt/HuntsRepositoryLocalTest.kt
@@ -1,6 +1,5 @@
 package com.swentseekr.seekr.model.hunt
 
-import com.swentseekr.seekr.model.author.Author
 import com.swentseekr.seekr.model.map.Location
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -23,7 +22,7 @@ class HuntsRepositoryLocalTest {
           time = 2.5,
           distance = 5.0,
           difficulty = Difficulty.EASY,
-          author = Author("spike man", "", 1, 2.5, 3.0),
+          authorId = "0",
           image = 2,
           reviewRate = 4.5)
 

--- a/app/src/test/java/com/swentseekr/seekr/ui/OverviewViewModelTest.kt
+++ b/app/src/test/java/com/swentseekr/seekr/ui/OverviewViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.swentseekr.seekr.ui
 
-import com.swentseekr.seekr.model.author.Author
 import com.swentseekr.seekr.model.hunt.*
 import com.swentseekr.seekr.model.map.Location
 import com.swentseekr.seekr.ui.overview.OverviewViewModel
@@ -32,7 +31,7 @@ class OverviewViewModelTest {
           time = 1.0,
           distance = 2.0,
           difficulty = Difficulty.EASY,
-          author = Author("Alice", "", 1, 1.0, 1.0),
+          authorId = "0",
           image = 1,
           reviewRate = 4.0)
 


### PR DESCRIPTION
### User Story
As a user, I want to see all the available hunts in order to explore and choose the ones I am interested in.

### Task
Add repository based on Firebase Firestore.

### Description
This PR introduces a new HuntsRepositoryFirestore implementation that uses Firebase Firestore to persist and retrieve Hunt data. It replaces the previous in-memory implementation via HuntRepositoryProvider. Change the Hunt object the parameter author is replaced by an author id.

### What has been changed?

- Added HuntsRepositoryFirestore.kt
- Modified HuntRepositoryProvider to use Firestore as the default repository.
- Modified the object Hunt

### Why was this change made?
Made this change in order to use Firebase Firestore and not a LocalRepository. Change the Hunt object because we need an author id.

### Checklist

- [x] Unit tests were added for HuntsRepositoryFirestore
- [x] All new and existing tests pass locally (./gradlew test)
- [x] Code coverage was improved and verified for Firestore-related logic

