### PR TITLE
Add Firestore security rules

### DIFF
--- a/firestore-rules.txt
+++ b/firestore-rules.txt
@@ -1,0 +1,29 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    match /profiles/{userId} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /hunts/{huntId} {
+      allow read: if true;
+      allow write: if request.auth != null
+                   && request.auth.uid == request.resource.data.authorId;
+    }
+
+    match /users/{userId} {
+
+      match /doneHunts/{huntId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+      match /likedHunts/{huntId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
# **User Story**
As a user, I want to be the only one able to modify my profile in order to respect my privacy.  

---

# **Task Reference**
**Task:** Implement **secure Firestore rules** for profiles, hunts, and user-specific hunt data  
**Related Feature:** [Firestore security](https://github.com/SwentSeekr/seekr/issues/135)  
**Related Issue:** https://github.com/SwentSeekr/seekr/issues/146

---

# **Description**
This PR introduces updated **Firestore Security Rules** to ensure user privacy while maintaining global visibility of hunts and profiles. It aligns Firestore access control with the intended behavior of the app and prevents unauthorized reads or writes that previously caused `PERMISSION_DENIED` errors.

### Key additions:
- **Profiles**
  - Profiles are now **publicly readable** so users can explore each other’s accounts.
  - Only the authenticated user who owns a profile can **create, update, or delete** it.

- **Hunts**
  - All hunts are **publicly readable**, allowing all users to browse available content.
  - Only the user whose UID matches the `authorId` field can **create/update/delete** a hunt.

- **User subcollections**
  - Each user’s `doneHunts` and `likedHunts` folders are now protected:
    - Only the owner can read or write items inside these collections.
  - Prevents unauthorized access to personal hunt activity.

---

# **Notes**
- This code and PR description were produced with the help of AI.
