### PR TITLE
improve ReviewImagesScreen with full-screen image viewer and UI elements

### DIFF
--- a/app/src/androidTest/java/com/swentseekr/seekr/ui/review/ReviewImagesScreenTest.kt
+++ b/app/src/androidTest/java/com/swentseekr/seekr/ui/review/ReviewImagesScreenTest.kt
@@ -12,6 +12,14 @@ import org.junit.Rule
 import org.junit.Test
 
 class ReviewImagesScreenTest {
+  val time: Long = 500
+
+  private fun setReviewImagesScreen(photos: List<String>) {
+    composeRule.setContent { ReviewImagesScreen(photoUrls = photos, onGoBack = {}) }
+    composeRule.waitForIdle()
+    composeRule.mainClock.advanceTimeBy(time)
+    composeRule.waitForIdle()
+  }
 
   @get:Rule val composeRule = createComposeRule()
 
@@ -30,7 +38,6 @@ class ReviewImagesScreenTest {
       ReviewImagesScreen(photoUrls = photos, onGoBack = { backClicked = true })
     }
 
-    // Wait for initial composition
     composeRule.waitForIdle()
 
     // Assert that the screen is displayed
@@ -97,7 +104,7 @@ class ReviewImagesScreenTest {
 
     pager.performTouchInput { swipeLeft() }
 
-    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.mainClock.advanceTimeBy(time)
     composeRule.waitForIdle()
 
     // Check second image
@@ -105,7 +112,7 @@ class ReviewImagesScreenTest {
 
     pager.performTouchInput { swipeLeft() }
 
-    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.mainClock.advanceTimeBy(time)
     composeRule.waitForIdle()
 
     // Check third image
@@ -139,17 +146,13 @@ class ReviewImagesScreenTest {
             ReviewImagesScreenConstantStings.Photo2,
             ReviewImagesScreenConstantStings.Photo3)
 
-    // Set content
-    composeRule.setContent { ReviewImagesScreen(photoUrls = photos, onGoBack = {}) }
-    composeRule.waitForIdle()
-    composeRule.mainClock.advanceTimeBy(500)
-    composeRule.waitForIdle()
+    setReviewImagesScreen(photos)
 
     // Click on the first image box
     composeRule.onNodeWithTag("ReviewImageBox_0").performClick()
 
     composeRule.waitForIdle()
-    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.mainClock.advanceTimeBy(time)
     composeRule.waitForIdle()
 
     val fullscreenPager = composeRule.onNodeWithTag("FullScreenImagePager", useUnmergedTree = true)
@@ -158,7 +161,7 @@ class ReviewImagesScreenTest {
     // Swipe left in fullscreen
     fullscreenPager.performTouchInput { swipeLeft() }
 
-    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.mainClock.advanceTimeBy(time)
     composeRule.waitForIdle()
 
     fullscreenPager.assertExists()
@@ -167,7 +170,7 @@ class ReviewImagesScreenTest {
     composeRule.onNodeWithTag("FullScreenImageDialog", useUnmergedTree = true).performClick()
 
     composeRule.waitForIdle()
-    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.mainClock.advanceTimeBy(time)
     composeRule.waitForIdle()
 
     composeRule.onNodeWithTag("FullScreenImageDialog", useUnmergedTree = true).assertDoesNotExist()
@@ -181,17 +184,13 @@ class ReviewImagesScreenTest {
             ReviewImagesScreenConstantStings.Photo2,
             ReviewImagesScreenConstantStings.Photo3)
 
-    composeRule.setContent { ReviewImagesScreen(photoUrls = photos, onGoBack = {}) }
-
-    composeRule.waitForIdle()
-    composeRule.mainClock.advanceTimeBy(500)
-    composeRule.waitForIdle()
+    setReviewImagesScreen(photos)
 
     // Click on the first image to open fullscreen at index 0
     composeRule.onNodeWithTag("ReviewImageBox_0").performClick()
 
     composeRule.waitForIdle()
-    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.mainClock.advanceTimeBy(time)
     composeRule.waitForIdle()
 
     val fullscreenPager = composeRule.onNodeWithTag("FullScreenImagePager", useUnmergedTree = true)
@@ -199,7 +198,7 @@ class ReviewImagesScreenTest {
 
     fullscreenPager.performTouchInput { swipeLeft() }
 
-    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.mainClock.advanceTimeBy(time)
     composeRule.waitForIdle()
 
     fullscreenPager.assertExists()
@@ -208,7 +207,7 @@ class ReviewImagesScreenTest {
     composeRule.onNodeWithTag("FullScreenImageDialog", useUnmergedTree = true).performClick()
 
     composeRule.waitForIdle()
-    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.mainClock.advanceTimeBy(time)
     composeRule.waitForIdle()
 
     composeRule.onNodeWithTag("FullScreenImageDialog", useUnmergedTree = true).assertDoesNotExist()
@@ -222,17 +221,13 @@ class ReviewImagesScreenTest {
             ReviewImagesScreenConstantStings.Photo2,
             ReviewImagesScreenConstantStings.Photo3)
 
-    composeRule.setContent { ReviewImagesScreen(photoUrls = photos, onGoBack = {}) }
-
-    composeRule.waitForIdle()
-    composeRule.mainClock.advanceTimeBy(500)
-    composeRule.waitForIdle()
+    setReviewImagesScreen(photos)
 
     // swipe to the second image in the main pager
     val mainPager = composeRule.onNodeWithTag("ReviewImagePager")
     mainPager.performTouchInput { swipeLeft() }
 
-    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.mainClock.advanceTimeBy(time)
     composeRule.waitForIdle()
 
     composeRule.onNodeWithTag("ReviewImageIndexText").assertTextEquals("Image #2/${photos.size}")
@@ -241,13 +236,12 @@ class ReviewImagesScreenTest {
     composeRule.onNodeWithTag("ReviewImageBox_1").performClick()
 
     composeRule.waitForIdle()
-    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.mainClock.advanceTimeBy(time)
     composeRule.waitForIdle()
 
     // Verify fullscreen dialog opened
     composeRule.onNodeWithTag("FullScreenImageDialog", useUnmergedTree = true).assertExists()
 
-    // The fullscreen pager should start at index 1
     composeRule.onNodeWithTag("FullScreenImagePager", useUnmergedTree = true).assertExists()
 
     composeRule.onNodeWithTag("FullScreenImageDialog", useUnmergedTree = true).performClick()

--- a/app/src/main/java/com/swentseekr/seekr/ui/hunt/review/ReviewImagesScreen.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/hunt/review/ReviewImagesScreen.kt
@@ -39,6 +39,14 @@ import androidx.compose.ui.window.DialogProperties
 import coil.compose.AsyncImage
 import com.swentseekr.seekr.R
 
+/**
+ * Displays a screen allowing the user to review a list of images with a paging UI
+ * * and optional full-screen viewing.
+ *
+ * @param photoUrls the list of image URLs to display in this screen pager.
+ * @param onGoBack callback when the user cancels or navigates back.
+ * @param modifier a modifier
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReviewImagesScreen(
@@ -50,7 +58,7 @@ fun ReviewImagesScreen(
   val scroll = rememberScrollState()
   val pagerState = rememberPagerState(pageCount = { photoUrls.size })
   var showFullScreen by remember { mutableStateOf(false) }
-  var fullscreenIndex by remember { mutableStateOf(0) }
+  var fullscreenIndex by remember { mutableStateOf(ReviewImagesScreenConstants.StartIndex) }
 
   Scaffold(
       topBar = {
@@ -88,7 +96,7 @@ fun ReviewImagesScreen(
                   Modifier.padding(bottom = ReviewImagesScreenConstants.TextBottomPadding)
                       .testTag(ReviewImagesScreenConstantsStrings.ReviewImageInfoTexteTestTag))
 
-          val index = pagerState.currentPage + 1
+          val index = pagerState.currentPage + ReviewImagesScreenConstants.One
           HorizontalPager(
               state = pagerState,
               modifier =
@@ -143,6 +151,13 @@ fun ReviewImagesScreen(
   }
 }
 
+/**
+ * Displays a full-screen dialog that allows the user to swipe through a collection of images.
+ *
+ * @param images the list of image URLs to display in the full-screen pager.
+ * @param startIndex the index of the image that should be shown first when the full-screen opens.
+ * @param onClose callback invoked when the user dismisses the dialog (by tipping on the screen)
+ */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FullScreenImageViewer(
@@ -155,7 +170,6 @@ fun FullScreenImageViewer(
         Box(
             modifier =
                 Modifier.fillMaxSize()
-                    .fillMaxWidth()
                     .background(MaterialTheme.colorScheme.background)
                     .clickable { onClose() }
                     .testTag(
@@ -173,7 +187,7 @@ fun FullScreenImageViewer(
                     AsyncImage(
                         model = images[page],
                         contentDescription =
-                            "${ReviewImagesScreenConstantsStrings.ReviewImageFullScreenImageDescription} ${page + 1}",
+                            "${ReviewImagesScreenConstantsStrings.ReviewImageFullScreenImageDescription} ${page + ReviewImagesScreenConstants.One}",
                         modifier = Modifier.fillMaxSize(),
                     )
                   }

--- a/app/src/main/java/com/swentseekr/seekr/ui/hunt/review/ReviewImagesScreenConstants.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/hunt/review/ReviewImagesScreenConstants.kt
@@ -2,6 +2,7 @@ package com.swentseekr.seekr.ui.hunt.review
 
 import androidx.compose.ui.unit.dp
 
+/** Constant string and test tag used in ReviewImagesScreen */
 object ReviewImagesScreenConstantsStrings {
   const val Title = "Images Review"
   const val BackButtonTag = "back_button"
@@ -22,6 +23,7 @@ object ReviewImagesScreenConstantsStrings {
   const val EndTopText = "swipe to view other images."
 }
 
+/** Constant number used in ReviewImagesScreen */
 object ReviewImagesScreenConstants {
   val PaddingColumn = 16.dp
   val PaddingImage = 8.dp
@@ -31,4 +33,6 @@ object ReviewImagesScreenConstants {
   val RoundShape = 16.dp
   val ImageSize = 400.dp
   val TextTopPadding = 8.dp
+  const val StartIndex = 0
+  const val One = 1
 }


### PR DESCRIPTION
### User Story
As a user, I want to be able to review hunts I took part of in order to share my experience and help others decide which hunts to try.

### Task
Improve the UI of review images screen 

### Description
This pull request is about improving the UI of the review image screen in order to have a better design. Now the images are swappable on left and right and when clicking on an image it's became the full screen. 

### Video

https://github.com/user-attachments/assets/90e5aa24-aff1-4bff-b651-15babc41ca15






### What has been changed?

Improve ReviewImagesScreen :
- Change the way of displaying the review pictures. 
- Make the pictures swappable
-  Add the possibility to display the photo on the full screen when we click on it 

Add ReviewImagesScreenConstants contains the constants values of the file ReviewImagesScreen

Change ReviewImagesScreenTest in order to be in line with the new UI 


### Checklist

- [x] Improve the UI of the review images screen
- [x] Add the possibility to swip to see other pictures related to this review 
- [x] Add the possibility of full screen
- [x] Add some test for a better coverage

_Note assisted by AI for coding_