### PR TITLE
Implement navigation on all hunts tabs

### DIFF
--- a/app/src/main/java/com/swentseekr/seekr/ui/profile/Profile.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/profile/Profile.kt
@@ -248,11 +248,7 @@ fun ProfileScreen(
 
                     val base = Modifier.testTag(ProfileTestTags.getTestTagForHuntCard(hunt, index))
 
-                    val clickable =
-                        if (selectedTab == ProfileTab.MY_HUNTS)
-                            base.clickable { onMyHuntClick(hunt.uid) }
-                        else base
-
+                    val clickable = base.clickable { onMyHuntClick(hunt.uid) }
                     HuntCard(
                         hunt = hunt,
                         isLiked = profile.likedHunts.any { it.uid == hunt.uid },


### PR DESCRIPTION
### User Story
As a user, I want to easily navigate in the app in order to find the information I need quickly and with minimal effort.

### Task
Profile like and done hunts navigates to the hunt card screen.

### Description
Add the navigation for the like and done hunt in our profile. We can click on the Hunt Card of the like or done tab and navigates to the HuntCardScreen.

### Video

https://github.com/user-attachments/assets/efbe7bd9-d793-41a8-8984-a785f74511b4



### What has been changed?
Change an if statement in the profile in a no if val clickable = base.clickable { onMyHuntClick(hunt.uid) }

