### PR TITLE
feat: add time and distances suggestions

### DIFF
--- a/app/src/main/java/com/swentseekr/seekr/ui/hunt/BaseHuntFieldsConstants.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/hunt/BaseHuntFieldsConstants.kt
@@ -50,9 +50,9 @@ object BaseHuntFieldsStrings {
   const val LABEL_DIFFICULTY = "Difficulty"
   const val EXPAND_DIFFICULTY_DESC = "Expand Difficulty"
   const val LABEL_TIME = "Estimated Time (hours)"
-  const val PLACEHOLDER_TIME = "e.g., 1.5"
+  const val PLACEHOLDER_TIME = "(leave empty for suggested time)"
   const val LABEL_DISTANCE = "Distance (km)"
-  const val PLACEHOLDER_DISTANCE = "e.g., 2.3"
+  const val PLACEHOLDER_DISTANCE = "(leave empty for suggested distance)"
 
   // Screens
   const val TITLE_DEFAULT = "Add your Hunt"
@@ -148,6 +148,12 @@ object BaseHuntConstantsDefault {
   const val DEFAULT_LONGITUDE_2: Double = 1.0
   const val POLYLINE = 2
   const val ONE = 1
+  const val EMPTY_DISTANCE = 0.0
+  const val FUN_SPEED = 4.0
+  const val DISCOVER_SPEED = 4.5
+  const val SPORT_SPEED = 6.5
+  const val DEFAULT_SPEED = 5.0
+  const val KILOMETER = 1000.0
 }
 
 object HuntScreenTestTags {

--- a/app/src/main/java/com/swentseekr/seekr/ui/hunt/BaseHuntViewModel.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/hunt/BaseHuntViewModel.kt
@@ -15,6 +15,7 @@ import com.swentseekr.seekr.ui.map.MapConfig
 import com.swentseekr.seekr.ui.map.computeDistanceMetersRaw
 import com.swentseekr.seekr.ui.map.requestDirectionsPolyline
 import java.util.Locale
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -58,7 +59,8 @@ data class HuntUIState(
 }
 
 abstract class BaseHuntViewModel(
-    protected val repository: HuntsRepository = HuntRepositoryProvider.repository
+    protected val repository: HuntsRepository = HuntRepositoryProvider.repository,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
 
   protected val _uiState = MutableStateFlow(HuntUIState())
@@ -307,7 +309,7 @@ abstract class BaseHuntViewModel(
     viewModelScope.launch {
       val polyline: List<LatLng> =
           try {
-            withContext(Dispatchers.IO) {
+            withContext(ioDispatcher) {
               requestDirectionsPolyline(
                   originLat = origin.latitude,
                   originLng = origin.longitude,

--- a/app/src/main/java/com/swentseekr/seekr/ui/hunt/BaseHuntViewModel.kt
+++ b/app/src/main/java/com/swentseekr/seekr/ui/hunt/BaseHuntViewModel.kt
@@ -4,15 +4,23 @@ import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.auth.FirebaseAuth
+import com.swentseekr.seekr.BuildConfig
 import com.swentseekr.seekr.model.hunt.*
 import com.swentseekr.seekr.model.map.Location
 import com.swentseekr.seekr.ui.hunt.add.AddHuntViewModel
 import com.swentseekr.seekr.ui.hunt.edit.EditHuntViewModel
+import com.swentseekr.seekr.ui.map.MapConfig
+import com.swentseekr.seekr.ui.map.computeDistanceMetersRaw
+import com.swentseekr.seekr.ui.map.requestDirectionsPolyline
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 data class HuntUIState(
     val title: String = "",
@@ -57,6 +65,14 @@ abstract class BaseHuntViewModel(
   open val uiState: StateFlow<HuntUIState> = _uiState.asStateFlow()
 
   private var testMode: Boolean = false
+
+  private var lastSuggestedTime: String? = null
+  private var lastSuggestedDistance: String? = null
+  private var userOverrodeTime: Boolean = false
+  private var userOverrodeDistance: Boolean = false
+
+  private var cachedPointsKey: String? = null
+  private var cachedRouteDistanceKm: Double? = null
 
   protected var otherImagesUris: List<Uri> = emptyList()
 
@@ -158,6 +174,8 @@ abstract class BaseHuntViewModel(
   }
 
   fun setTime(time: String) {
+    userOverrodeTime = time.isNotBlank() && time != lastSuggestedTime
+
     _uiState.value =
         _uiState.value.copy(
             time = time,
@@ -166,6 +184,8 @@ abstract class BaseHuntViewModel(
   }
 
   fun setDistance(distance: String) {
+    userOverrodeDistance = distance.isNotBlank() && distance != lastSuggestedDistance
+
     _uiState.value =
         _uiState.value.copy(
             distance = distance,
@@ -180,6 +200,8 @@ abstract class BaseHuntViewModel(
 
   fun setStatus(status: HuntStatus) {
     _uiState.value = _uiState.value.copy(status = status)
+
+    applyAutoTimeAndDistanceSuggestions(_uiState.value.points, statusChanged = true)
   }
 
   fun setPoints(points: List<Location>): Boolean {
@@ -189,6 +211,12 @@ abstract class BaseHuntViewModel(
     }
     _uiState.value = _uiState.value.copy(points = points)
     clearErrorMsg()
+
+    cachedPointsKey = null
+    cachedRouteDistanceKm = null
+
+    applyAutoTimeAndDistanceSuggestions(points, statusChanged = false)
+
     return true
   }
 
@@ -231,4 +259,141 @@ abstract class BaseHuntViewModel(
   abstract fun buildHunt(state: HuntUIState): Hunt
 
   protected abstract suspend fun persist(hunt: Hunt)
+
+  /**
+   * Computes and applies suggested distance and time values based on the current hunt points.
+   *
+   * Distance is estimated using the Google Directions API in WALKING mode, summing the resulting
+   * polyline segments to obtain an actual walking distance through streets.
+   *
+   * Time is derived from the computed distance and an assumed walking speed that depends on the
+   * hunt status (FUN, DISCOVER, SPORT). If no status is set, a default speed is used.
+   *
+   * This method respects user input:
+   * - Suggested values are only applied if the corresponding field has not been manually overridden
+   *   by the user, or if the field is currently blank.
+   * - Manually edited values are never overwritten automatically.
+   *
+   * To improve responsiveness, the walking distance is cached for the current set of points. When
+   * this method is triggered by a status change, the cached distance is reused and only the time is
+   * recomputed.
+   *
+   * Asynchronous Direction API results are ignored if the hunt points change while the request is
+   * in flight, preventing stale suggestions from being applied.
+   *
+   * @param points The ordered list of hunt checkpoints (start → waypoints → end).
+   * @param statusChanged Whether this invocation was triggered by a status change. When true, the
+   *   cached distance (if available) is reused instead of issuing a new Directions request.
+   */
+  private fun applyAutoTimeAndDistanceSuggestions(points: List<Location>, statusChanged: Boolean) {
+    if (points.size < BaseHuntConstantsDefault.POLYLINE) return
+
+    val state = _uiState.value
+    val pointsKey = pointsKey(points)
+
+    val cachedKm =
+        if (statusChanged && cachedPointsKey == pointsKey) cachedRouteDistanceKm else null
+
+    if (cachedKm != null) {
+      applySuggestionsFromDistanceKm(cachedKm, state.status)
+      return
+    }
+
+    val origin = points.first()
+    val dest = points.last()
+    val waypoints = points.subList(1, points.size - 1).map { it.latitude to it.longitude }
+    val snapshot = points.toList()
+
+    viewModelScope.launch {
+      val polyline: List<LatLng> =
+          try {
+            withContext(Dispatchers.IO) {
+              requestDirectionsPolyline(
+                  originLat = origin.latitude,
+                  originLng = origin.longitude,
+                  destLat = dest.latitude,
+                  destLng = dest.longitude,
+                  waypoints = waypoints,
+                  travelMode = MapConfig.TRAVEL_MODE_WALKING,
+                  apiKey = BuildConfig.MAPS_API_KEY)
+            }
+          } catch (_: Exception) {
+            emptyList()
+          }
+
+      if (_uiState.value.points != snapshot) return@launch
+      if (polyline.size < BaseHuntConstantsDefault.POLYLINE) return@launch
+
+      val distanceKm = polylineDistanceKm(polyline)
+      if (distanceKm <= BaseHuntConstantsDefault.EMPTY_DISTANCE) return@launch
+
+      cachedPointsKey = pointsKey
+      cachedRouteDistanceKm = distanceKm
+
+      applySuggestionsFromDistanceKm(distanceKm, _uiState.value.status)
+    }
+  }
+
+  private fun applySuggestionsFromDistanceKm(distanceKm: Double, status: HuntStatus?) {
+    val state = _uiState.value
+
+    val suggestedDistance = formatDecimal(distanceKm)
+    val speed = suggestedSpeedKmh(status)
+    val suggestedTimeHours = distanceKm / speed
+    val suggestedTime = formatDecimal(suggestedTimeHours)
+
+    val shouldUpdateDistance =
+        !userOverrodeDistance || state.distance.isBlank() || state.distance == lastSuggestedDistance
+    val shouldUpdateTime =
+        !userOverrodeTime || state.time.isBlank() || state.time == lastSuggestedTime
+
+    if (shouldUpdateDistance) {
+      lastSuggestedDistance = suggestedDistance
+      _uiState.value =
+          _uiState.value.copy(
+              distance = suggestedDistance,
+              invalidDistanceMsg =
+                  if (suggestedDistance.toDoubleOrNull() == null)
+                      BaseHuntViewModelMessages.INVALID_DISTANCE
+                  else null)
+    }
+
+    if (shouldUpdateTime) {
+      lastSuggestedTime = suggestedTime
+      _uiState.value =
+          _uiState.value.copy(
+              time = suggestedTime,
+              invalidTimeMsg =
+                  if (suggestedTime.toDoubleOrNull() == null) BaseHuntViewModelMessages.INVALID_TIME
+                  else null)
+    }
+
+    if (state.distance.isBlank()) userOverrodeDistance = false
+    if (state.time.isBlank()) userOverrodeTime = false
+  }
+
+  private fun suggestedSpeedKmh(status: HuntStatus?): Double {
+    return when (status) {
+      HuntStatus.FUN -> BaseHuntConstantsDefault.FUN_SPEED
+      HuntStatus.DISCOVER -> BaseHuntConstantsDefault.DISCOVER_SPEED
+      HuntStatus.SPORT -> BaseHuntConstantsDefault.SPORT_SPEED
+      null -> BaseHuntConstantsDefault.DEFAULT_SPEED
+    }
+  }
+
+  private fun polylineDistanceKm(path: List<LatLng>): Double {
+    var meters = 0.0
+    for (i in 0 until path.lastIndex) {
+      meters += computeDistanceMetersRaw(path[i], path[i + 1])
+    }
+    return meters / BaseHuntConstantsDefault.KILOMETER
+  }
+
+  private fun pointsKey(points: List<Location>): String =
+      points.joinToString("|") { "${it.latitude},${it.longitude}" }
+
+  private fun formatDecimal(value: Double): String {
+    val s = String.format(Locale.US, "%.2f", value)
+    return s.trimEnd('0').trimEnd('.')
+  }
 }

--- a/app/src/test/java/com/swentseekr/seekr/model/hunt/BaseHuntViewModelSuggestionsTest.kt
+++ b/app/src/test/java/com/swentseekr/seekr/model/hunt/BaseHuntViewModelSuggestionsTest.kt
@@ -1,0 +1,164 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.swentseekr.seekr.model.hunt
+
+import com.google.android.gms.maps.model.LatLng
+import com.swentseekr.seekr.model.map.Location
+import com.swentseekr.seekr.ui.hunt.BaseHuntViewModel
+import com.swentseekr.seekr.ui.hunt.HuntUIState
+import com.swentseekr.seekr.ui.map.computeDistanceMetersRaw
+import com.swentseekr.seekr.ui.map.requestDirectionsPolyline
+import io.mockk.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class BaseHuntViewModelSuggestionsTest {
+
+  private val testDispatcher = StandardTestDispatcher()
+
+  private class TestVm(ioDispatcher: kotlinx.coroutines.CoroutineDispatcher) :
+      BaseHuntViewModel(repository = mockk(relaxed = true), ioDispatcher = ioDispatcher) {
+    override fun buildHunt(state: HuntUIState): Hunt = mockk(relaxed = true)
+
+    override suspend fun persist(hunt: Hunt) {}
+  }
+
+  private lateinit var vm: TestVm
+
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+
+    mockkStatic(::requestDirectionsPolyline)
+    mockkStatic(::computeDistanceMetersRaw)
+
+    vm = TestVm(ioDispatcher = testDispatcher)
+  }
+
+  @After
+  fun tearDown() {
+    unmockkStatic(::requestDirectionsPolyline)
+    unmockkStatic(::computeDistanceMetersRaw)
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun AutoSuggestionsUsesDirectionsAndCachesDistanceWhenStatusChanges() = runTest {
+    val points =
+        listOf(
+            Location(latitude = 46.0, longitude = 6.0, ""),
+            Location(latitude = 46.001, longitude = 6.001, ""),
+            Location(latitude = 46.002, longitude = 6.002, ""),
+        )
+
+    every {
+      requestDirectionsPolyline(
+          originLat = any(),
+          originLng = any(),
+          destLat = any(),
+          destLng = any(),
+          waypoints = any(),
+          travelMode = any(),
+          apiKey = any())
+    } returns listOf(LatLng(0.0, 0.0), LatLng(0.0, 0.01))
+
+    every { computeDistanceMetersRaw(any(), any()) } returns 1000.0
+
+    assertTrue(vm.setPoints(points))
+    advanceUntilIdle()
+
+    val firstTime = vm.uiState.value.time
+    val firstDistance = vm.uiState.value.distance
+    assertTrue("distance should be suggested", firstDistance.isNotBlank())
+    assertTrue("time should be suggested", firstTime.isNotBlank())
+    assertNull(vm.uiState.value.invalidDistanceMsg)
+    assertNull(vm.uiState.value.invalidTimeMsg)
+
+    vm.setStatus(HuntStatus.FUN)
+    advanceUntilIdle()
+
+    verify(exactly = 1) {
+      requestDirectionsPolyline(any(), any(), any(), any(), any(), any(), any())
+    }
+
+    val funTime = vm.uiState.value.time
+    assertNotEquals("time should be recomputed for new status", firstTime, funTime)
+
+    vm.setStatus(HuntStatus.SPORT)
+    advanceUntilIdle()
+
+    val sportTime = vm.uiState.value.time
+    assertNotEquals("time should change again for another status", funTime, sportTime)
+  }
+
+  @Test
+  fun AutoSuggestionsNotAppliedWhenPolylineIsTooShort() = runTest {
+    val points =
+        listOf(
+            Location(latitude = 46.0, longitude = 6.0, ""),
+            Location(latitude = 46.001, longitude = 6.001, ""),
+            Location(latitude = 46.002, longitude = 6.002, ""),
+        )
+
+    every { requestDirectionsPolyline(any(), any(), any(), any(), any(), any(), any()) } returns
+        emptyList()
+    every { computeDistanceMetersRaw(any(), any()) } returns 1000.0
+
+    assertTrue(vm.setPoints(points))
+    advanceUntilIdle()
+
+    assertEquals("", vm.uiState.value.distance)
+    assertEquals("", vm.uiState.value.time)
+
+    verify(exactly = 0) { computeDistanceMetersRaw(any(), any()) }
+  }
+
+  @Test
+  fun AutoSuggestionsNotAppliedWhenComputedDistanceIsZero() = runTest {
+    val points =
+        listOf(
+            Location(latitude = 46.0, longitude = 6.0, ""),
+            Location(latitude = 46.001, longitude = 6.001, ""),
+            Location(latitude = 46.002, longitude = 6.002, ""),
+        )
+
+    every { requestDirectionsPolyline(any(), any(), any(), any(), any(), any(), any()) } returns
+        listOf(LatLng(0.0, 0.0), LatLng(0.0, 0.01))
+
+    every { computeDistanceMetersRaw(any(), any()) } returns 0.0
+
+    assertTrue(vm.setPoints(points))
+    advanceUntilIdle()
+
+    assertEquals("", vm.uiState.value.distance)
+    assertEquals("", vm.uiState.value.time)
+  }
+
+  @Test
+  fun AutoSuggestionsDoesNotOverrideUserEnteredTimeOrDistance() = runTest {
+    val points =
+        listOf(
+            Location(latitude = 46.0, longitude = 6.0, ""),
+            Location(latitude = 46.001, longitude = 6.001, ""),
+            Location(latitude = 46.002, longitude = 6.002, ""),
+        )
+
+    every { requestDirectionsPolyline(any(), any(), any(), any(), any(), any(), any()) } returns
+        listOf(LatLng(0.0, 0.0), LatLng(0.0, 0.01))
+
+    every { computeDistanceMetersRaw(any(), any()) } returns 1500.0
+
+    vm.setTime("9")
+    vm.setDistance("9")
+
+    assertTrue(vm.setPoints(points))
+    advanceUntilIdle()
+
+    assertEquals("9", vm.uiState.value.time)
+    assertEquals("9", vm.uiState.value.distance)
+  }
+}


### PR DESCRIPTION
## User Story

**As a user, I want to create a new hunt with its main details in order to share it with others.**

---

## Task Reference
**Tasks:** Implement a suggested time when creating a Hunt and the distance by default (closes #310)
**Related:** Hunt creation flow, Map integration, Directions API usage

---

## Description

This PR enhances the hunt creation experience by automatically suggesting the total distance and estimated duration of a hunt based on the selected checkpoints.

The distance is computed using the Google Directions API in walking mode, ensuring the estimate reflects real paths and streets rather than straight-line distances. The suggested duration is derived from this distance using a walking speed that adapts to the selected hunt category (4 km/h in Fun, 4.5 km/h in Discover, 6.5 km/h in Sport, and a base 5 km/h until a category is selected).

The suggested values are non-intrusive: they act as helpful defaults and never override values manually entered by the user. Whenever checkpoints or the hunt category change, the suggestions are recomputed to stay consistent with the current configuration.

---

## Key Changes

### Hunt Creation Logic
- Automatically computes total hunt distance using:
  - Google Directions API (walking mode)
  - Polyline-based distance aggregation
- Automatically suggests an estimated duration derived from distance.

### Category-Based Time Estimation
- Adjusted assumed walking speed based on hunt category:
  - Fun: slower pace (4 km/h)
  - Discover: moderate pace (4.5 km/h)
  - Sport: faster pace (6.5 km/h)
- Falls back to a default walking speed (5 km/h) if no category is selected.

### Reactive Updates
- Suggestions update automatically when:
  - checkpoints are added
  - hunt category/status changes
- Distance computation is cached per checkpoint set to avoid unnecessary recomputation.

### User Input Safety
- Manually edited distance or time fields are never overridden.
- Clearing a field allows suggestions to be applied again.

---

## Demo

https://github.com/user-attachments/assets/d6b80064-12cb-4618-8e74-f06eb0d33933

---

## Checklist

- [x] Integrated walking-route distance calculation via Directions API
- [x] Added automatic distance and time suggestions during hunt creation
- [x] Implemented category-based walking speed logic
- [x] Ensured suggestions update on points and category changes
- [x] Preserved full user control over editable fields
- [x] Added unit test coverage in the existing test architecture

---

Note: this pull request was developed with the use of AI.